### PR TITLE
Fix env generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A docker compose file is provided to simplify running the entire stack.
 
 2. Clone this repository on your server.
 
-3. Create the backend environment file. A helper script fills in reasonable defaults:
+3. Create the backend environment file. A helper script fills in reasonable defaults from `.env.example` and `.devcontainer/.env.example`:
 
    ```bash
    cd pwned-proxy-backend

--- a/pwned-proxy-backend/.gitignore
+++ b/pwned-proxy-backend/.gitignore
@@ -1,8 +1,7 @@
 # Byte-compiled / optimized / DLL files
 *.env*
 !.env.example
-!.env.dev.example
-!.env.prod.example
+!.devcontainer/.env.example
 *__pycache__*
 *.old
 *.log

--- a/pwned-proxy-backend/README.md
+++ b/pwned-proxy-backend/README.md
@@ -20,9 +20,10 @@ The `generate_env.sh` helper can create the template files:
 ./generate_env.sh
 ```
 
-This populates `.env` and `.devcontainer/.env` using the example templates and
-should be run before starting Docker or the Dev Container. Edit the created
-files and replace any placeholders.
+This populates `.env` and `.devcontainer/.env` using the provided example
+templates (`.env.example` and `.devcontainer/.env.example`) and should be run
+before starting Docker or the Dev Container. Edit the created files and replace
+any placeholders.
 
 Set `DJANGO_DEBUG=true` in your `.env` to enable Django's debug mode.
 

--- a/pwned-proxy-backend/generate_env.py
+++ b/pwned-proxy-backend/generate_env.py
@@ -12,8 +12,10 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent
 
 EXAMPLES = {
-    'prod': BASE_DIR / '.env.prod.example',
-    'devcontainer': BASE_DIR / '.env.dev.example',
+    # Example file used when generating the production .env
+    'prod': BASE_DIR / '.env.example',
+    # Example file used when generating the Dev Container .env
+    'devcontainer': BASE_DIR / '.devcontainer' / '.env.example',
 }
 TARGETS = {
     'prod': BASE_DIR / '.env',


### PR DESCRIPTION
## Summary
- adjust environment script to use correct example file paths
- document the correct example file names in backend quickstart and repo README
- update `.gitignore` accordingly

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`
- `./generate_env.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874d886230c832c96479219746989fe