### PR TITLE
Update docker-compose to use published images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,7 @@
 version: "3.9"
 services:
   backend:
-    build:
-      context: ./pwned-proxy-backend
-      dockerfile: .devcontainer/Dockerfile.prod
+    image: dtuait/pwned-proxy-app-main:python-3.13-bullseye-django-5.1.6-myversion-1.0.2
     env_file:
       - ./pwned-proxy-backend/.env
     depends_on:
@@ -11,9 +9,7 @@ services:
     ports:
       - "8000:8000"
   frontend:
-    build:
-      context: ./pwned-proxy-frontend/app-main
-      dockerfile: Dockerfile
+    image: dtuait/nextjs-devcontainer-app-main:nodejs22-1.0.0
     env_file:
       - ./pwned-proxy-frontend/app-main/.env.local
     depends_on:


### PR DESCRIPTION
## Summary
- use published backend image instead of building from Dockerfile
- use published frontend image instead of building from Dockerfile

## Testing
- `pip install pyyaml`
- `python3 - <<'EOF'
import yaml
with open('docker-compose.yaml') as f:
    data=yaml.safe_load(f)
print(data['services'].keys())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6874d8d33edc832ca5abe0b730d58ed1