### PR TITLE
Fix docker compose DB env vars

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,10 +21,8 @@ services:
       - "3000:3000"
   db:
     image: postgres:14-alpine
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-db}
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    env_file:
+      - ./pwned-proxy-backend/.env
     volumes:
       - postgres_data:/var/lib/postgresql/data
 volumes:


### PR DESCRIPTION
## Summary
- pass backend `.env` to the PostgreSQL container so its credentials match

## Testing
- `python pwned-proxy-backend/app-main/manage.py test api.tests.test_urls -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6874e2aceabc832c876801e1c8bac48a