### PR TITLE
Fix devcontainer workspace and add backend venv

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,5 +6,11 @@ RUN apt-get update && apt-get install -y curl gnupg \
     && apt-get install -y nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Create Python virtual environment for the backend
+RUN python -m venv /usr/venv/backend
+
+# Ensure the virtual environment's binaries are first in PATH
+ENV PATH="/usr/venv/backend/bin:$PATH"
+
 # Set default workdir
-WORKDIR /workspace
+WORKDIR /usr/src/project

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "customizations": {
         "vscode": {
             "settings": {
-                "python.defaultInterpreterPath": "/usr/local/bin/python"
+                "python.defaultInterpreterPath": "/usr/venv/backend/bin/python"
             },
             "extensions": [
                 "ms-python.vscode-pylance",

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -3,8 +3,13 @@ set -e
 
 echo "Running postStartCommand.sh..."
 
-# Install backend Python dependencies
-pip install --no-cache-dir -r pwned-proxy-backend/.devcontainer/requirements.txt
+# Ensure Python virtual environment exists
+if [ ! -d /usr/venv/backend ]; then
+    python -m venv /usr/venv/backend
+fi
+
+# Install backend Python dependencies inside the virtual environment
+/usr/venv/backend/bin/pip install --no-cache-dir -r pwned-proxy-backend/.devcontainer/requirements.txt
 
 # Install frontend Node dependencies
 pushd pwned-proxy-frontend/app-main >/dev/null

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.defaultInterpreterPath": "/usr/local/bin/python",
+    "python.defaultInterpreterPath": "/usr/venv/backend/bin/python",
     "python.terminal.activateEnvironment": false,
     "typescript.preferences.importModuleSpecifier": "relative",
     "editor.formatOnSave": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -119,7 +119,7 @@
         {
             "label": "Start Backend (Django)",
             "type": "shell",
-            "command": "python",
+            "command": "/usr/venv/backend/bin/python",
             "args": [
                 "manage.py",
                 "runserver",
@@ -161,7 +161,7 @@
         {
             "label": "Django Migrate",
             "type": "shell",
-            "command": "python",
+            "command": "/usr/venv/backend/bin/python",
             "args": [
                 "manage.py",
                 "migrate"


### PR DESCRIPTION
## Summary
- set WORKDIR in devcontainer Dockerfile to `/usr/src/project`
- create backend virtual environment in `/usr/venv/backend`
- use the venv's Python as the default interpreter
- install backend requirements inside the venv on startup
- update VS Code settings and tasks to use the venv Python

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6877820f5980832c8a57cb7ef8dbe21f