### PR TITLE
Fix missing DB password when running locally

### DIFF
--- a/pwned-proxy-backend/envutils.py
+++ b/pwned-proxy-backend/envutils.py
@@ -22,6 +22,12 @@ def ensure_env(base_dir: Path) -> None:
         'DJANGO_SUPERUSER_USERNAME': f"admin_{secrets.token_hex(4)}",
         'DJANGO_SUPERUSER_PASSWORD': secrets.token_urlsafe(16),
         'DJANGO_DEBUG': 'false',
+        # Provide database settings so `manage.py runserver` works without
+        # running `generate_env.sh` first. These match the defaults used by
+        # Docker Compose.
+        'POSTGRES_DB': 'db',
+        'POSTGRES_USER': 'postgres',
+        'POSTGRES_PASSWORD': secrets.token_urlsafe(16),
     }
 
     with open(env_path, 'w') as fh:


### PR DESCRIPTION
## Summary
- default POSTGRES credentials when `.env` does not exist

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68778352d638832ca06d2b5f1eb1b66e