### PR TITLE
Fix devcontainer requirements path

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -10,7 +10,7 @@ if [ ! -d /usr/venv/backend ]; then
 fi
 
 # Install backend Python dependencies inside the virtual environment
-/usr/venv/backend/bin/pip install --no-cache-dir -r pwned-proxy-backend/.devcontainer/requirements.txt
+/usr/venv/backend/bin/pip install --no-cache-dir -r pwned-proxy-backend/requirements.txt
 
 
 # Install frontend Node dependencies


### PR DESCRIPTION
## Summary
- fix the Python requirements path in `postStartCommand.sh`

## Testing
- `pip install -r requirements.txt`
- `python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68778531410c832c8f3eb6699fba0cb4