### PR TITLE
Rename dev DB service to dev-db

### DIFF
--- a/.devcontainer/DEVELOPMENT_GUIDE.md
+++ b/.devcontainer/DEVELOPMENT_GUIDE.md
@@ -76,10 +76,10 @@ Use `Ctrl+Shift+P` → "Tasks: Run Task" and select:
 ## Database
 
 The PostgreSQL database is automatically started with the devcontainer and is accessible at:
-- **Host**: `db` (from within devcontainer) or `localhost` (from host)
+- **Host**: `dev-db` (from within devcontainer) or `localhost` (from host)
 - **Port**: `5432`
-- **Database**: `pwned_proxy`
-- **Username**: `postgres` 
+- **Database**: `dev-db`
+- **Username**: `postgres`
 - **Password**: `postgres`
 
 ## Environment Files

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,28 +12,28 @@ services:
     environment:
       - PYTHONPATH=/usr/src/project
     depends_on:
-      - db
+      - dev-db
     networks:
       - devnet
     stdin_open: true
     tty: true
     command: sleep infinity
 
-  db:
+  dev-db:
     image: postgres:14-alpine
     environment:
-      - POSTGRES_DB=pwned_proxy
+      - POSTGRES_DB=dev-db
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - de:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     networks:
       - devnet
 
 volumes:
-  postgres_data:
+  de:
 
 networks:
   devnet:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ cat ./pwned-proxy-combined/pwned-proxy-backend/.env
 # Generate strong values at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new
 
 # PostgreSQL configuration
-POSTGRES_DB=db
+POSTGRES_DB=dev-db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=ElxMBu0b5Ya9165uCmbEXQ
 

--- a/pwned-proxy-backend/.env.example
+++ b/pwned-proxy-backend/.env.example
@@ -3,7 +3,7 @@
 # Generate strong values at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new
 
 # PostgreSQL configuration
-POSTGRES_DB=db
+POSTGRES_DB=dev-db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=<postgres_password>
 

--- a/pwned-proxy-backend/app-main/pwned_proxy/settings.py
+++ b/pwned-proxy-backend/app-main/pwned_proxy/settings.py
@@ -137,10 +137,10 @@ WSGI_APPLICATION = 'pwned_proxy.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('POSTGRES_DB', 'db'),
+        'NAME': os.getenv('POSTGRES_DB', 'dev-db'),
         'USER': os.getenv('POSTGRES_USER', 'postgres'),
         'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
-        'HOST': 'db',  # matches docker-compose service name
+        'HOST': 'dev-db',  # matches docker-compose service name
         'PORT': '5432',
     }
 }

--- a/pwned-proxy-backend/app-main/wait_for_db.py
+++ b/pwned-proxy-backend/app-main/wait_for_db.py
@@ -2,9 +2,9 @@ import time
 import os
 import psycopg2
 
-host = os.getenv('POSTGRES_HOST', 'db')
+host = os.getenv('POSTGRES_HOST', 'dev-db')
 port = int(os.getenv('POSTGRES_PORT', 5432))
-db = os.getenv('POSTGRES_DB', 'db')
+db = os.getenv('POSTGRES_DB', 'dev-db')
 user = os.getenv('POSTGRES_USER', 'postgres')
 password = os.getenv('POSTGRES_PASSWORD', '')
 

--- a/pwned-proxy-backend/envutils.py
+++ b/pwned-proxy-backend/envutils.py
@@ -25,7 +25,7 @@ def ensure_env(base_dir: Path) -> None:
         # Provide database settings so `manage.py runserver` works without
         # running `generate_env.sh` first. These match the defaults used by
         # Docker Compose.
-        'POSTGRES_DB': 'db',
+        'POSTGRES_DB': 'dev-db',
         'POSTGRES_USER': 'postgres',
         'POSTGRES_PASSWORD': secrets.token_urlsafe(16),
     }


### PR DESCRIPTION
## Summary
- rename DB service in devcontainer compose to `dev-db`
- update volume name to `de`
- document new DB info
- adjust defaults and examples for `dev-db` usage

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68778d611edc832cb1f67fd1155d4909