### PR TITLE
Ensure admin user exists in devcontainer

### DIFF
--- a/.devcontainer/DEVELOPMENT_GUIDE.md
+++ b/.devcontainer/DEVELOPMENT_GUIDE.md
@@ -4,7 +4,9 @@
 
 ### In Development Container
 
-1. **Set up environment variables:**
+1. **Set up environment variables (optional):**
+   The dev container automatically generates `pwned-proxy-backend/.env` on first
+   start. Re-run `generate_env.sh` only if you want to regenerate the file.
    ```bash
    cd /usr/src/project/pwned-proxy-backend
    ./generate_env.sh
@@ -15,23 +17,13 @@
    source /usr/venv/backend/bin/activate
    ```
 
-3. **Install Python dependencies:**
+3. **Install Python dependencies (optional):**
+   Dependencies are installed during container startup, but you can run this
+   command to update them.
    ```bash
    pip install -r requirements.txt
    ```
-
-4. **Run database migrations:**
-   ```bash
-   cd /usr/src/project/pwned-proxy-backend
-   python manage.py migrate
-   ```
-
-5. **Create a superuser (optional):**
-   ```bash
-   python manage.py createsuperuser
-   ```
-
-6. **Start the Django development server:**
+4. **Start the Django development server:**
    ```bash
    python manage.py runserver 0.0.0.0:8000
    ```

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -23,6 +23,11 @@ if [ ! -f pwned-proxy-backend/.env ]; then
     (cd pwned-proxy-backend && ./generate_env.sh)
 fi
 
+# Apply migrations and create the default admin user
+/usr/venv/backend/bin/python pwned-proxy-backend/app-main/wait_for_db.py
+/usr/venv/backend/bin/python pwned-proxy-backend/app-main/manage.py migrate --noinput
+/usr/venv/backend/bin/python pwned-proxy-backend/app-main/create_admin.py
+
 # Copy frontend env if missing
 if [ ! -f pwned-proxy-frontend/app-main/.env.local ]; then
     cp pwned-proxy-frontend/app-main/.env.local.example pwned-proxy-frontend/app-main/.env.local


### PR DESCRIPTION
## Summary
- create default superuser during devcontainer setup
- update devcontainer docs for automatic setup

## Testing
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/app-main/manage.py test api.tests.test_urls -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6877a32812e0832c98e2483ba6a66678