### PR TITLE
Fix DB host mismatch

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "3000:3000"
     environment:
       - PYTHONPATH=/usr/src/project
+      - POSTGRES_HOST=dev-db
     depends_on:
       - dev-db
     networks:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ $ cat ./pwned-proxy-combined/pwned-proxy-backend/.env
 # Generate strong values at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new
 
 # PostgreSQL configuration
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
 POSTGRES_DB=dev-db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=ElxMBu0b5Ya9165uCmbEXQ

--- a/pwned-proxy-backend/.env.example
+++ b/pwned-proxy-backend/.env.example
@@ -3,6 +3,8 @@
 # Generate strong values at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new
 
 # PostgreSQL configuration
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
 POSTGRES_DB=dev-db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=<postgres_password>

--- a/pwned-proxy-backend/app-main/pwned_proxy/settings.py
+++ b/pwned-proxy-backend/app-main/pwned_proxy/settings.py
@@ -140,8 +140,8 @@ DATABASES = {
         'NAME': os.getenv('POSTGRES_DB', 'dev-db'),
         'USER': os.getenv('POSTGRES_USER', 'postgres'),
         'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
-        'HOST': 'dev-db',  # matches docker-compose service name
-        'PORT': '5432',
+        'HOST': os.getenv('POSTGRES_HOST', 'db'),  # matches docker-compose service name
+        'PORT': os.getenv('POSTGRES_PORT', '5432'),
     }
 }
 

--- a/pwned-proxy-backend/app-main/wait_for_db.py
+++ b/pwned-proxy-backend/app-main/wait_for_db.py
@@ -2,7 +2,7 @@ import time
 import os
 import psycopg2
 
-host = os.getenv('POSTGRES_HOST', 'dev-db')
+host = os.getenv('POSTGRES_HOST', 'db')
 port = int(os.getenv('POSTGRES_PORT', 5432))
 db = os.getenv('POSTGRES_DB', 'dev-db')
 user = os.getenv('POSTGRES_USER', 'postgres')

--- a/pwned-proxy-backend/envutils.py
+++ b/pwned-proxy-backend/envutils.py
@@ -25,6 +25,7 @@ def ensure_env(base_dir: Path) -> None:
         # Provide database settings so `manage.py runserver` works without
         # running `generate_env.sh` first. These match the defaults used by
         # Docker Compose.
+        'POSTGRES_HOST': 'db',
         'POSTGRES_DB': 'dev-db',
         'POSTGRES_USER': 'postgres',
         'POSTGRES_PASSWORD': secrets.token_urlsafe(16),


### PR DESCRIPTION
## Summary
- load `POSTGRES_HOST` for Django DB settings and wait script
- include host variables in `.env.example` and README
- add `POSTGRES_HOST` default in envutils
- pass `POSTGRES_HOST` to devcontainer

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877a5af1bfc832c8f835591a7333f35