### PR TITLE
Add group names endpoint

### DIFF
--- a/pwned-proxy-backend/app-main/api/tests/test_urls.py
+++ b/pwned-proxy-backend/app-main/api/tests/test_urls.py
@@ -18,6 +18,7 @@ class URLPatternsTest(SimpleTestCase):
             ("latest-breach", {}, views.LatestBreachProxyView),
             ("data-classes", {}, views.DataClassesProxyView),
             ("subscription-status", {}, views.SubscriptionStatusProxyView),
+            ("group-names", {}, views.GroupNamesView),
         ]
         for name, kwargs, view in tests:
             with self.subTest(name=name):

--- a/pwned-proxy-backend/app-main/api/urls.py
+++ b/pwned-proxy-backend/app-main/api/urls.py
@@ -16,6 +16,7 @@ from .views import (
     LatestBreachProxyView,
     DataClassesProxyView,
     SubscriptionStatusProxyView,
+    GroupNamesView,
 )
 
 urlpatterns = [
@@ -61,4 +62,5 @@ urlpatterns = [
         SubscriptionStatusProxyView.as_view(),
         name="subscription-status",
     ),
+    path("group-names", GroupNamesView.as_view(), name="group-names"),
 ]

--- a/pwned-proxy-backend/app-main/api/views.py
+++ b/pwned-proxy-backend/app-main/api/views.py
@@ -447,3 +447,12 @@ class SubscriptionStatusProxyView(LoggedAPIView):
             return Response({"detail": "No valid API key."}, status=401)
         resp = hibp_get("subscription/status")
         return make_response(resp)
+
+
+class GroupNamesView(LoggedAPIView):
+    """GET /api/v3/group-names"""
+
+    @swagger_auto_schema(auto_schema=None)
+    def get(self, request):
+        names = list(Group.objects.order_by("name").values_list("name", flat=True))
+        return Response(names, status=200)

--- a/pwned-proxy-frontend/app-main/app/about/page.tsx
+++ b/pwned-proxy-frontend/app-main/app/about/page.tsx
@@ -3,19 +3,19 @@
 import { useEffect, useState } from "react";
 
 export default function AboutPage() {
-  const [domains, setDomains] = useState<string[] | null>(null);
+  const [groups, setGroups] = useState<string[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch("/api/subscribed-domains");
-        if (!res.ok) throw new Error(`Failed to load domains: ${res.status}`);
+        const res = await fetch("/api/group-names");
+        if (!res.ok) throw new Error(`Failed to load groups: ${res.status}`);
         const data = await res.json();
         if (!Array.isArray(data) || data.length === 0) {
-          throw new Error("No domain list returned");
+          throw new Error("No group list returned");
         }
-        setDomains(data as string[]);
+        setGroups(data as string[]);
       } catch (err) {
         setError((err as Error).message);
       }
@@ -27,7 +27,7 @@ export default function AboutPage() {
     return <div className="p-4 text-red-600">Error: {error}</div>;
   }
 
-  if (!domains) {
+  if (!groups) {
     return <div className="p-4">Loading…</div>;
   }
 
@@ -53,8 +53,8 @@ export default function AboutPage() {
         </p>
         <h2 className="text-xl font-semibold mt-6">Subscribed Universities</h2>
         <ul className="list-disc pl-5 text-left space-y-1">
-          {domains.map((d) => (
-            <li key={d}>{d}</li>
+          {groups.map((g) => (
+            <li key={g}>{g}</li>
           ))}
         </ul>
         {/* Download Postman collection from public/haveibeenpwned.deic.dk.postman_collection_v2.json */}

--- a/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+    'http://api.haveibeenpwned.cert.dk'
+  ).replace(/\/$/, '');
+  const apiKey = process.env.HIBP_API_KEY ?? '';
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v3/group-names`, {
+      headers: {
+        'X-API-Key': apiKey,
+        accept: 'application/json',
+      },
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Backend API error: ${response.status}`, details: text },
+        { status: response.status }
+      );
+    }
+
+    const data = JSON.parse(text);
+    if (!Array.isArray(data) || data.length === 0) {
+      return NextResponse.json(
+        { error: 'No groups returned from backend' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add API endpoint to expose Django group names
- hide new endpoint from swagger docs
- fetch group names on the about page
- add Next.js route for group names
- update tests for new endpoint

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6877a82cfcc4832ca13aba8e1e03fbee