### PR TITLE
Fix waiting for DB in devcontainer

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -23,6 +23,11 @@ if [ ! -f pwned-proxy-backend/.env ]; then
     (cd pwned-proxy-backend && ./generate_env.sh)
 fi
 
+# Export backend environment variables so helper scripts can access them
+set -a
+source pwned-proxy-backend/.env
+set +a
+
 # Apply migrations and create the default admin user
 /usr/venv/backend/bin/python pwned-proxy-backend/app-main/wait_for_db.py
 /usr/venv/backend/bin/python pwned-proxy-backend/app-main/manage.py migrate --noinput


### PR DESCRIPTION
## Summary
- ensure postStartCommand exports backend `.env` variables

## Testing
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877ab392db8832c844e7f12d4e7f0fd