### PR TITLE
Fix production env generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ git clone https://github.com/dtuait/pwned-proxy-combined
 ### 2. Prepare backend environment
 
 Generate the `.env` file by running `generate_env.sh` inside the backend
-directory. This creates `.env` with random values:
+directory. This creates `.env` with random values, including a secure
+PostgreSQL password for the production database:
 
 
 
@@ -52,7 +53,7 @@ $ cat ./pwned-proxy-combined/pwned-proxy-backend/.env
 # PostgreSQL configuration
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-POSTGRES_DB=dev-db
+POSTGRES_DB=production-db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=ElxMBu0b5Ya9165uCmbEXQ
 

--- a/pwned-proxy-backend/.env.example
+++ b/pwned-proxy-backend/.env.example
@@ -5,7 +5,7 @@
 # PostgreSQL configuration
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-POSTGRES_DB=dev-db
+POSTGRES_DB=production-db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=<postgres_password>
 

--- a/pwned-proxy-backend/Dockerfile
+++ b/pwned-proxy-backend/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+# Install build dependencies and sudo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential sudo && rm -rf /var/lib/apt/lists/*
+
+# Create application user with passwordless sudo
+RUN useradd --create-home --shell /bin/bash appuser && echo "appuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/appuser
+
+# Create virtual environment for the app
+RUN python -m venv /usr/src/venvs/app-main
+ENV PATH="/usr/src/venvs/app-main/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /usr/src/project
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN chown -R appuser:appuser /usr/src/project
+
+USER appuser
+
+EXPOSE 8000
+ENTRYPOINT ["/usr/src/project/entrypoint.sh"]

--- a/pwned-proxy-backend/README.md
+++ b/pwned-proxy-backend/README.md
@@ -41,9 +41,7 @@ superuser is created automatically. If the `.env` file was generated, all
 generated values including the admin credentials are printed and stored in that
 file so you can reuse them across restarts.
 
-When deploying with `docker-compose-coolify.yaml`, ports `80` and `443` are
-mapped to the internal port `8000` so the application is reachable at the
-provided domain without specifying a port.
+
 
 ### Using a custom domain
 

--- a/pwned-proxy-backend/app-main/pwned_proxy/settings.py
+++ b/pwned-proxy-backend/app-main/pwned_proxy/settings.py
@@ -137,7 +137,7 @@ WSGI_APPLICATION = 'pwned_proxy.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('POSTGRES_DB', 'dev-db'),
+        'NAME': os.getenv('POSTGRES_DB', 'production-db'),
         'USER': os.getenv('POSTGRES_USER', 'postgres'),
         'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
         'HOST': os.getenv('POSTGRES_HOST', 'db'),  # matches docker-compose service name

--- a/pwned-proxy-backend/app-main/wait_for_db.py
+++ b/pwned-proxy-backend/app-main/wait_for_db.py
@@ -4,7 +4,7 @@ import psycopg2
 
 host = os.getenv('POSTGRES_HOST', 'db')
 port = int(os.getenv('POSTGRES_PORT', 5432))
-db = os.getenv('POSTGRES_DB', 'dev-db')
+db = os.getenv('POSTGRES_DB', 'production-db')
 user = os.getenv('POSTGRES_USER', 'postgres')
 password = os.getenv('POSTGRES_PASSWORD', '')
 

--- a/pwned-proxy-backend/check_env.py
+++ b/pwned-proxy-backend/check_env.py
@@ -7,7 +7,7 @@ import yaml
 
 BASE_DIR = Path(__file__).resolve().parent
 EXAMPLE = BASE_DIR / '.env.example'
-COMPOSE = BASE_DIR / 'docker-compose-coolify.yaml'
+COMPOSE = BASE_DIR.parent / 'docker-compose.yaml'
 
 
 def parse_compose(path: Path) -> set[str]:
@@ -44,7 +44,7 @@ def main() -> None:
     missing = compose_required - example_envs.keys()
     if missing:
         print(
-            'Environment variable mismatch between docker-compose-coolify.yaml and .env.example',
+            'Environment variable mismatch between docker-compose.yaml and .env.example',
             file=sys.stderr,
         )
         print('Missing in .env.example:', ', '.join(sorted(missing)), file=sys.stderr)


### PR DESCRIPTION
## Summary
- add missing backend Dockerfile for building the Django service
- default production environment to use `production-db`
- document production database and random password generation in README
- remove references to docker-compose-coolify
- adjust settings and helpers for new defaults

## Testing
- `pip install -q -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/app-main/manage.py test api -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6877ad638470832c9c3d662d9c91f4cb