### PR TITLE
Add production startup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,20 @@ Generate client API keys and download `seeded_api_keys.json`:
 ![Seed keys](https://supabase.vicre-nextjs-01.security.ait.dtu.dk/storage/v1/object/public/hibp-guide/5.2-django-seed-and-download-clienthibpkeys.png)
 
 
+### 6. Start production
+
+Run the stack in production mode with the following commands executed from the
+repository root:
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+You can achieve the same result in a single line:
+
+```bash
+docker compose build && docker compose up -d
+```
+
+


### PR DESCRIPTION
## Summary
- document how to build and start the stack in production

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877b2fa5114832cbf2b978a403ee096