### PR TITLE
Fix backend entrypoint script

### DIFF
--- a/pwned-proxy-backend/entrypoint.sh
+++ b/pwned-proxy-backend/entrypoint.sh
@@ -12,11 +12,11 @@ set -e
 STATIC_ROOT=/usr/src/project/app-main/staticfiles
 sudo install -d -m 0755 "$STATIC_ROOT" && sudo chown appuser:appuser "$STATIC_ROOT"
 
-/usr/src/venvs/app-main/bin/python wait_for_db.py
+/usr/src/venvs/app-main/bin/python app-main/wait_for_db.py
 
 /usr/src/venvs/app-main/bin/python manage.py migrate --noinput
 /usr/src/venvs/app-main/bin/python manage.py collectstatic --noinput
-/usr/src/venvs/app-main/bin/python create_admin.py
+/usr/src/venvs/app-main/bin/python app-main/create_admin.py
 # Run one-time setup tasks if HIBP_API_KEY is configured
 /usr/src/venvs/app-main/bin/python manage.py initial_setup || true
 


### PR DESCRIPTION
## Summary
- ensure entrypoint references correct paths for wait_for_db.py and create_admin.py

## Testing
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_6877da1a85e4832c952ff7f7538ce95a