### PR TITLE
Sanitize example secrets

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,3 +1,3 @@
 # Example env file for the dev container
 # Add your ngrok auth token if you want to expose services
-DEVCONTAINER_NGROK_AUTHTOKEN=
+DEVCONTAINER_NGROK_AUTHTOKEN=<long-ngrok-token>

--- a/pwned-proxy-backend/.env.example
+++ b/pwned-proxy-backend/.env.example
@@ -7,15 +7,15 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 POSTGRES_DB=production-db
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=<postgres_password>
+POSTGRES_PASSWORD=<long-secret-password>
 
 # Django secret key
-DJANGO_SECRET_KEY=<django_secret_key>
+DJANGO_SECRET_KEY=<long-secret-key>
 
 # These can be left empty; startup scripts will handle them
 DJANGO_SUPERUSER_USERNAME=
-DJANGO_SUPERUSER_PASSWORD=
-HIBP_API_KEY=
+DJANGO_SUPERUSER_PASSWORD=<long-secret-password>
+HIBP_API_KEY=<long-hibp-api-key>
 SERVICE_FQDN_APP=api.haveibeenpwned.cert.dk
 PWNED_PROXY_DOMAIN=api.haveibeenpwned.cert.dk
 

--- a/pwned-proxy-backend/check_env.py
+++ b/pwned-proxy-backend/check_env.py
@@ -55,8 +55,11 @@ def main() -> None:
         sys.exit(1)
 
     placeholders = {
-        'DJANGO_SECRET_KEY': '<django_secret_key>',
-        'POSTGRES_PASSWORD': '<postgres_password>',
+        'DJANGO_SECRET_KEY': '<long-secret-key>',
+        'POSTGRES_PASSWORD': '<long-secret-password>',
+        'DJANGO_SUPERUSER_PASSWORD': '<long-secret-password>',
+        'HIBP_API_KEY': '<long-hibp-api-key>',
+        'DEVCONTAINER_NGROK_AUTHTOKEN': '<long-ngrok-token>',
     }
 
     for key, placeholder in placeholders.items():

--- a/pwned-proxy-backend/generate_env.py
+++ b/pwned-proxy-backend/generate_env.py
@@ -18,8 +18,11 @@ TARGETS = {
 }
 
 PLACEHOLDERS = {
-    'DJANGO_SECRET_KEY': '<django_secret_key>',
-    'POSTGRES_PASSWORD': '<postgres_password>',
+    'DJANGO_SECRET_KEY': '<long-secret-key>',
+    'POSTGRES_PASSWORD': '<long-secret-password>',
+    'DJANGO_SUPERUSER_PASSWORD': '<long-secret-password>',
+    'HIBP_API_KEY': '<long-hibp-api-key>',
+    'DEVCONTAINER_NGROK_AUTHTOKEN': '<long-ngrok-token>',
 }
 
 


### PR DESCRIPTION
## Summary
- replace placeholder secrets in `.env.example` files with `<long-...>` variants
- update placeholder constants in backend scripts

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877da53d4c4832ca523778314856aab