### PR TITLE
Fix backend manage.py module path

### DIFF
--- a/pwned-proxy-backend/manage.py
+++ b/pwned-proxy-backend/manage.py
@@ -7,7 +7,14 @@ from pathlib import Path
 # When using Docker the working directory might not be the project root
 # (e.g. ``app-main``). Include the parent directory on ``sys.path`` so
 # that ``envutils`` can be imported by ``pwned_proxy.settings``.
-sys.path.append(str(Path(__file__).resolve().parent))
+BASE_DIR = Path(__file__).resolve().parent
+
+# Ensure both the project root and ``app-main`` are on ``sys.path`` so that
+# Django can locate the ``pwned_proxy`` package regardless of where the script
+# is executed from. This mirrors the logic in ``app-main/manage.py`` which adds
+# the parent directory when executed inside the container.
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "app-main"))
 
 
 def main():


### PR DESCRIPTION
## Summary
- ensure `pwned_proxy` package is on `sys.path` for Docker

## Testing
- `python - <<'PY'
import sys
sys.path.append('pwned-proxy-backend/app-main')
import pwned_proxy
print('imported pwned_proxy, path:', pwned_proxy.__file__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6877dd9ea78c832cabb5a2fd0e293905