### PR TITLE
Allow boot with placeholder HIBP key

### DIFF
--- a/pwned-proxy-backend/.env.example
+++ b/pwned-proxy-backend/.env.example
@@ -15,7 +15,7 @@ DJANGO_SECRET_KEY=<long-secret-key>
 # These can be left empty; startup scripts will handle them
 DJANGO_SUPERUSER_USERNAME=
 DJANGO_SUPERUSER_PASSWORD=<long-secret-password>
-HIBP_API_KEY=<long-hibp-api-key>
+HIBP_API_KEY=<dummy-hibp-key>
 SERVICE_FQDN_APP=api.haveibeenpwned.mydomain.com
 PWNED_PROXY_DOMAIN=api.haveibeenpwned.mydomain.com
 

--- a/pwned-proxy-backend/check_env.py
+++ b/pwned-proxy-backend/check_env.py
@@ -58,14 +58,22 @@ def main() -> None:
         'DJANGO_SECRET_KEY': '<long-secret-key>',
         'POSTGRES_PASSWORD': '<long-secret-password>',
         'DJANGO_SUPERUSER_PASSWORD': '<long-secret-password>',
-        'HIBP_API_KEY': '<long-hibp-api-key>',
+        'HIBP_API_KEY': '<dummy-hibp-key>',
         'DEVCONTAINER_NGROK_AUTHTOKEN': '<long-ngrok-token>',
     }
 
     for key, placeholder in placeholders.items():
         value = os.getenv(key)
-        if not value or value == placeholder or (key == 'DJANGO_SECRET_KEY' and value == 'change-this-to-a-random-secret-key'):
-            print(f'{key} must be set. Generate a secure value at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new', file=sys.stderr)
+        if key == 'HIBP_API_KEY' and (not value or value == placeholder):
+            print('HIBP_API_KEY not set; startup will continue.', file=sys.stderr)
+            continue
+        if not value or value == placeholder or (
+            key == 'DJANGO_SECRET_KEY' and value == 'change-this-to-a-random-secret-key'
+        ):
+            print(
+                f'{key} must be set. Generate a secure value at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new',
+                file=sys.stderr,
+            )
             sys.exit(1)
 
 

--- a/pwned-proxy-backend/generate_env.py
+++ b/pwned-proxy-backend/generate_env.py
@@ -21,7 +21,7 @@ PLACEHOLDERS = {
     'DJANGO_SECRET_KEY': '<long-secret-key>',
     'POSTGRES_PASSWORD': '<long-secret-password>',
     'DJANGO_SUPERUSER_PASSWORD': '<long-secret-password>',
-    'HIBP_API_KEY': '<long-hibp-api-key>',
+    'HIBP_API_KEY': '<dummy-hibp-key>',
     'DEVCONTAINER_NGROK_AUTHTOKEN': '<long-ngrok-token>',
 }
 


### PR DESCRIPTION
## Summary
- allow the server to start when `HIBP_API_KEY` is unset or contains the dummy placeholder
- update env example and generation scripts to use `<dummy-hibp-key>` placeholder

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python3 pwned-proxy-backend/manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877e2f91c28832c99a2cf209403c90e