### PR TITLE
Make ngrok token optional

### DIFF
--- a/pwned-proxy-backend/check_env.py
+++ b/pwned-proxy-backend/check_env.py
@@ -59,7 +59,6 @@ def main() -> None:
         'POSTGRES_PASSWORD': '<long-secret-password>',
         'DJANGO_SUPERUSER_PASSWORD': '<long-secret-password>',
         'HIBP_API_KEY': '<dummy-hibp-key>',
-        'DEVCONTAINER_NGROK_AUTHTOKEN': '<long-ngrok-token>',
     }
 
     for key, placeholder in placeholders.items():


### PR DESCRIPTION
## Summary
- allow start up without `DEVCONTAINER_NGROK_AUTHTOKEN`

## Testing
- `python3 -m pip install --user -r pwned-proxy-backend/requirements.txt`
- `cd pwned-proxy-backend/app-main && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6877e6387d1c832c8de1e85bba89ea59