### PR TITLE
Fix backend startup module path

### DIFF
--- a/pwned-proxy-backend/entrypoint.sh
+++ b/pwned-proxy-backend/entrypoint.sh
@@ -4,6 +4,12 @@ set -e
 # Validate environment before starting
 /usr/src/venvs/app-main/bin/python /usr/src/project/check_env.py
 
+# Ensure the Django package path is available when gunicorn
+# tries to import ``pwned_proxy.wsgi``. ``manage.py`` modifies
+# ``sys.path`` but gunicorn performs the import before any
+# project code runs, so the path must be configured here.
+export PYTHONPATH="/usr/src/project:/usr/src/project/app-main${PYTHONPATH:+:$PYTHONPATH}"
+
 
 # Ensure we can write to the STATIC_ROOT directory even if a
 # stale container image left it owned by root. This mirrors the


### PR DESCRIPTION
## Summary
- ensure gunicorn can import the Django package

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877ec2b2640832c9402aa810bd55890