### PR TITLE
Add interactive env setup

### DIFF
--- a/generate_env.sh
+++ b/generate_env.sh
@@ -12,5 +12,21 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 cp "$DIR/pwned-proxy-frontend/app-main/.env.local.example" \
    "$DIR/pwned-proxy-frontend/app-main/.env.local"
 
-echo "Environment files created. Add your HIBP key to .env and configure your" \
-     "domains in .env.local."
+# Prompt for HIBP key and domain
+printf "Enter your HIBP API key (leave blank to skip): "
+read -r hibp_key
+printf "Enter domain for the API [localhost:8000]: "
+read -r domain
+domain=${domain:-localhost:8000}
+
+# Update backend environment values
+backend_env="$DIR/pwned-proxy-backend/.env"
+sed -i "s/^HIBP_API_KEY=.*/HIBP_API_KEY=$hibp_key/" "$backend_env"
+sed -i "s#^SERVICE_FQDN_APP=.*#SERVICE_FQDN_APP=$domain#" "$backend_env"
+sed -i "s#^PWNED_PROXY_DOMAIN=.*#PWNED_PROXY_DOMAIN=$domain#" "$backend_env"
+
+# Update frontend environment values
+frontend_env="$DIR/pwned-proxy-frontend/app-main/.env.local"
+sed -i "s#^NEXT_PUBLIC_HIBP_PROXY_URL=.*#NEXT_PUBLIC_HIBP_PROXY_URL=http://$domain/#" "$frontend_env"
+
+echo "Environment files created."


### PR DESCRIPTION
## Summary
- add prompts for HIBP key and domain when running `generate_env.sh`
- automatically write the provided values to backend `.env` and frontend `.env.local`

## Testing
- `python3 -m pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python3 pwned-proxy-backend/manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6877ef6cb200832c991a248db62af5c0