### PR TITLE
Fix universities list by using local API fallback

### DIFF
--- a/pwned-proxy-frontend/README.md
+++ b/pwned-proxy-frontend/README.md
@@ -4,7 +4,7 @@
 
 Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_HIBP_PROXY_URL`
 if you wish to use a different API location. By default it points to
-`http://api.haveibeenpwned.cert.dk/`. This variable is read by the
+`http://localhost:8000/`. This variable is read by the
 start page and the header link so it also works when deployed with Coolify.
 
 ### Google Analytics

--- a/pwned-proxy-frontend/app-main/.env.local.example
+++ b/pwned-proxy-frontend/app-main/.env.local.example
@@ -1,6 +1,6 @@
 # Example frontend environment
 # Run `../../generate_env.sh` to copy this file to `.env.local`.
 # Adjust the domain and analytics settings as needed.
-NEXT_PUBLIC_HIBP_PROXY_URL=http://api.domainthatyouown.com/
+NEXT_PUBLIC_HIBP_PROXY_URL=http://localhost:8000/
 NEXT_PUBLIC_GA_MEASUREMENT_ID=<google_analytics_measurement_id>
 NEXT_PUBLIC_CONTACT_EMAIL=user@mail.com

--- a/pwned-proxy-frontend/app-main/app/api/breach-check/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/breach-check/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     // Server‑side call to your Django API – no CORS issues here
     const baseUrl = (
       process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'http://api.haveibeenpwned.cert.dk'
+      'http://localhost:8000'
     ).replace(/\/$/, '');
     const response = await fetch(
       `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`,

--- a/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   const baseUrl = (
     process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-    'http://api.haveibeenpwned.cert.dk'
+    'http://localhost:8000'
   ).replace(/\/$/, '');
   const apiKey = process.env.HIBP_API_KEY ?? '';
 

--- a/pwned-proxy-frontend/app-main/app/api/public-breach-check/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/public-breach-check/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
     // Server-side call to the Django API without requiring Authorization
     const baseUrl = (
       process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'http://api.haveibeenpwned.cert.dk'
+      'http://localhost:8000'
     ).replace(/\/$/, '');
     const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`;
     const response = await fetch(apiUrl, {

--- a/pwned-proxy-frontend/app-main/app/components/Header.tsx
+++ b/pwned-proxy-frontend/app-main/app/components/Header.tsx
@@ -47,7 +47,7 @@ export default function Header() {
         <Link
           href={
             process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-            'http://api.haveibeenpwned.cert.dk/'
+            'http://localhost:8000/'
           }
           target="_blank"
           rel="noopener noreferrer"

--- a/pwned-proxy-frontend/app-main/app/components/HomePage.tsx
+++ b/pwned-proxy-frontend/app-main/app/components/HomePage.tsx
@@ -71,7 +71,7 @@ export default function HomePage() {
       console.log('Email:', trimmedEmail);
 
       const baseUrl = (process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-        'http://api.haveibeenpwned.cert.dk').replace(/\/$/, '');
+        'http://localhost:8000').replace(/\/$/, '');
       const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}?includeUnverified=true`;
       
       const response = await fetch(apiUrl, {

--- a/pwned-proxy-frontend/app-main/app/welcome/page.tsx
+++ b/pwned-proxy-frontend/app-main/app/welcome/page.tsx
@@ -24,7 +24,7 @@ export default function WelcomePage() {
     try {
       const baseUrl = (
         process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-        'http://api.haveibeenpwned.cert.dk'
+        'http://localhost:8000'
       ).replace(/\/$/, '');
       const res = await fetch(
         `${baseUrl}/api/v3/stealer-logs-domain/dtu.dk/`,
@@ -117,7 +117,7 @@ export default function WelcomePage() {
           <iframe
             src={
               process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-              'http://api.haveibeenpwned.cert.dk/'
+              'http://localhost:8000/'
             }
             title="Backend API Preview"
             className="w-full min-h-full"
@@ -128,7 +128,7 @@ export default function WelcomePage() {
         <a
           href={
             process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-            'http://api.haveibeenpwned.cert.dk/'
+            'http://localhost:8000/'
           }
           target="_blank"
           rel="noopener noreferrer"

--- a/pwned-proxy-frontend/app-main/lib/api-config.ts
+++ b/pwned-proxy-frontend/app-main/lib/api-config.ts
@@ -1,7 +1,7 @@
 export const API_CONFIG = {
   BASE_URL:
     process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-    'http://api.haveibeenpwned.cert.dk',
+    'http://localhost:8000',
   ENDPOINTS: {
     // Endpoints that require email + apikey
     BREACHED_ACCOUNT: '/breached-account',           // GET 5) Breached Account (by email)


### PR DESCRIPTION
## Summary
- point frontend API calls at local backend when `NEXT_PUBLIC_HIBP_PROXY_URL` isn't set
- update default example URL and docs

## Testing
- `npm install`
- `npm run build`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6877f0c7d3cc832c91766da3845b1e79