### PR TITLE
Improve env generation

### DIFF
--- a/generate_env.sh
+++ b/generate_env.sh
@@ -12,6 +12,30 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 cp "$DIR/pwned-proxy-frontend/app-main/.env.local.example" \
    "$DIR/pwned-proxy-frontend/app-main/.env.local"
 
+frontend_env="$DIR/pwned-proxy-frontend/app-main/.env.local"
+
+# Prompt for frontend variables based on the example file
+while IFS= read -r raw; do
+  line="$(printf '%s' "$raw" | tr -d '\r')"
+  [ -z "$line" ] && continue
+  case "$line" in
+    \#*) continue ;;
+  esac
+  key="${line%%=*}"
+  default="${line#*=}"
+  printf "Enter value for %s [%s]: " "$key" "$default"
+  read -r value
+  if [ -z "$value" ]; then
+    if [ "$key" = "NEXTAUTH_SECRET" ]; then
+      value="$(openssl rand -base64 32 | tr -d '\n')"
+    else
+      value="$default"
+    fi
+  fi
+  esc="$(printf '%s' "$value" | sed -e 's/[&/]/\\&/g')"
+  sed -i "s#^${key}=.*#${key}=${esc}#" "$frontend_env"
+done < "$DIR/pwned-proxy-frontend/app-main/.env.local.example"
+
 # Prompt for HIBP key and domain
 printf "Enter your HIBP API key (leave blank to skip): "
 read -r hibp_key
@@ -24,9 +48,5 @@ backend_env="$DIR/pwned-proxy-backend/.env"
 sed -i "s/^HIBP_API_KEY=.*/HIBP_API_KEY=$hibp_key/" "$backend_env"
 sed -i "s#^SERVICE_FQDN_APP=.*#SERVICE_FQDN_APP=$domain#" "$backend_env"
 sed -i "s#^PWNED_PROXY_DOMAIN=.*#PWNED_PROXY_DOMAIN=$domain#" "$backend_env"
-
-# Update frontend environment values
-frontend_env="$DIR/pwned-proxy-frontend/app-main/.env.local"
-sed -i "s#^NEXT_PUBLIC_HIBP_PROXY_URL=.*#NEXT_PUBLIC_HIBP_PROXY_URL=http://$domain/#" "$frontend_env"
 
 echo "Environment files created."


### PR DESCRIPTION
## Summary
- generate frontend `.env.local` by prompting for each variable
- generate random `NEXTAUTH_SECRET` when not provided
- keep backend `.env` generation and prompts

## Testing
- `python3 pwned-proxy-backend/manage.py test pwned-proxy-backend/app-main/api/tests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6877f4c17dd4832c823a373445fb13e6