### PR TITLE
Handle empty group list gracefully

### DIFF
--- a/pwned-proxy-frontend/app-main/app/about/page.tsx
+++ b/pwned-proxy-frontend/app-main/app/about/page.tsx
@@ -12,8 +12,8 @@ export default function AboutPage() {
         const res = await fetch("/api/group-names");
         if (!res.ok) throw new Error(`Failed to load groups: ${res.status}`);
         const data = await res.json();
-        if (!Array.isArray(data) || data.length === 0) {
-          throw new Error("No group list returned");
+        if (!Array.isArray(data)) {
+          throw new Error("Invalid group list returned");
         }
         setGroups(data as string[]);
       } catch (err) {
@@ -53,9 +53,11 @@ export default function AboutPage() {
         </p>
         <h2 className="text-xl font-semibold mt-6">Subscribed Universities</h2>
         <ul className="list-disc pl-5 text-left space-y-1">
-          {groups.map((g) => (
-            <li key={g}>{g}</li>
-          ))}
+          {groups.length > 0 ? (
+            groups.map((g) => <li key={g}>{g}</li>)
+          ) : (
+            <li className="list-none">No groups configured</li>
+          )}
         </ul>
         {/* Download Postman collection from public/haveibeenpwned.deic.dk.postman_collection_v2.json */}
         <div className="mt-8 flex justify-center">

--- a/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
@@ -24,9 +24,9 @@ export async function GET() {
     }
 
     const data = JSON.parse(text);
-    if (!Array.isArray(data) || data.length === 0) {
+    if (!Array.isArray(data)) {
       return NextResponse.json(
-        { error: 'No groups returned from backend' },
+        { error: 'Invalid groups payload from backend' },
         { status: 500 }
       );
     }


### PR DESCRIPTION
## Summary
- fix API error handling in group-names route
- avoid crashing when group list is empty on About page

## Testing
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/manage.py test api -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6877fbeed7b4832c8655a76a11add464