### PR TITLE
Automate group seeding on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ had their own HaveIBeenPwned subscription, providing the same service for free.
 
 ### First time setup
 
-When the backend container starts for the first time it will apply migrations, create a superuser and, if `HIBP_API_KEY`
-was provided, import initial data. On subsequent starts the value of `HIBP_API_KEY` in `pwned-proxy-backend/.env` is
-used to update the stored key automatically. The credentials are printed in the backend logs.
+When the backend container starts for the first time it will apply migrations and create a superuser. If `HIBP_API_KEY`
+is set a fresh domain list is imported. Regardless of whether the key is provided, the predefined groups are seeded
+with API keys so the proxy works out of the box. On subsequent starts the value of `HIBP_API_KEY` in
+`pwned-proxy-backend/.env` is used to update the stored key automatically. The credentials are printed in the backend
+logs.
 
 You can access the frontend at [http://localhost:3000](http://localhost:3000) and the Django admin interface at
 [http://localhost:8000/admin/](http://localhost:8000/admin/).

--- a/pwned-proxy-backend/app-main/api/management/commands/initial_setup.py
+++ b/pwned-proxy-backend/app-main/api/management/commands/initial_setup.py
@@ -6,60 +6,64 @@ from api.admin import SEED_DATA
 import os
 import json
 
+
 class Command(BaseCommand):
     help = "Perform initial setup using HIBP_API_KEY if provided."
 
     def handle(self, *args, **options):
-        hibp_key_env = os.getenv('HIBP_API_KEY')
-        if not hibp_key_env:
-            self.stdout.write(self.style.WARNING('HIBP_API_KEY not set; skipping initial setup.'))
-            return
-
+        hibp_key_env = os.getenv("HIBP_API_KEY")
         created = False
         hibp_obj = HIBPKey.objects.first()
 
-        if hibp_obj:
-            if hibp_obj.api_key != hibp_key_env:
-                hibp_obj.api_key = hibp_key_env
-                if not hibp_obj.description:
-                    hibp_obj.description = 'Updated key from .env'
-                hibp_obj.save()
-                self.stdout.write(self.style.SUCCESS('Updated HIBP API key.'))
+        if hibp_key_env:
+            if hibp_obj:
+                if hibp_obj.api_key != hibp_key_env:
+                    hibp_obj.api_key = hibp_key_env
+                    if not hibp_obj.description:
+                        hibp_obj.description = "Updated key from .env"
+                    hibp_obj.save()
+                    self.stdout.write(self.style.SUCCESS("Updated HIBP API key."))
+                else:
+                    self.stdout.write("HIBP API key already configured and up to date.")
             else:
-                self.stdout.write('HIBP API key already configured and up to date.')
+                HIBPKey.objects.create(
+                    api_key=hibp_key_env, description="Initial key from .env"
+                )
+                self.stdout.write(self.style.SUCCESS("Added HIBP API key."))
+                created = True
+
+            if created:
+                # Import domains only when a new key was added
+                call_command("import_domain_data")
         else:
-            HIBPKey.objects.create(api_key=hibp_key_env, description='Initial key from .env')
-            self.stdout.write(self.style.SUCCESS('Added HIBP API key.'))
-            created = True
+            self.stdout.write(
+                self.style.WARNING("HIBP_API_KEY not set; skipping domain import.")
+            )
 
-        if not created:
-            # Key already existed; nothing else to set up
-            return
+        # Seed groups if they haven't been created yet
+        seed_group_names = [item["group"] for item in SEED_DATA]
+        existing = APIKey.objects.filter(group__name__in=seed_group_names)
+        if existing.exists():
+            self.stdout.write("Group API keys already exist; skipping seeding.")
+        else:
+            APIKey.objects.filter(group__name__in=seed_group_names).delete()
 
-        # Import domains
-        call_command('import_domain_data')
+            results = []
+            for item in SEED_DATA:
+                group_name = item["group"]
+                base_domain = item["domain"]
+                group, _ = Group.objects.get_or_create(name=group_name)
+                api_key_obj, raw_key = APIKey.create_api_key(group=group)
+                matching = Domain.objects.filter(name__endswith=base_domain)
+                api_key_obj.domains.add(*matching)
+                results.append({"group": group_name, "api_key": raw_key})
 
-        # Seed groups
-        seed_group_names = [item['group'] for item in SEED_DATA]
-        APIKey.objects.filter(group__name__in=seed_group_names).delete()
-
-        results = []
-        for item in SEED_DATA:
-            group_name = item['group']
-            base_domain = item['domain']
-            group, _ = Group.objects.get_or_create(name=group_name)
-            api_key_obj, raw_key = APIKey.create_api_key(group=group)
-            matching = Domain.objects.filter(name__endswith=base_domain)
-            api_key_obj.domains.add(*matching)
-            results.append({'group': group_name, 'api_key': raw_key})
-
-        for res in results:
-            self.stdout.write(f"{res['group']}: {res['api_key']}")
+            for res in results:
+                self.stdout.write(f"{res['group']}: {res['api_key']}")
 
         # Also print admin credentials from env if available
-        admin_user = os.getenv('DJANGO_SUPERUSER_USERNAME', 'admin')
-        admin_pass = os.getenv('DJANGO_SUPERUSER_PASSWORD', '')
+        admin_user = os.getenv("DJANGO_SUPERUSER_USERNAME", "admin")
+        admin_pass = os.getenv("DJANGO_SUPERUSER_PASSWORD", "")
         self.stdout.write(f"Admin user: {admin_user}")
         if admin_pass:
             self.stdout.write(f"Admin password: {admin_pass}")
-


### PR DESCRIPTION
## Summary
- automatically run seed groups during initial backend setup
- note automatic seeding in the README

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python3 pwned-proxy-backend/manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_6877fe0272b8832cbe37612c87ff94a4