### PR TITLE
fix frontend group listing

### DIFF
--- a/pwned-proxy-frontend/app-main/.env.local.example
+++ b/pwned-proxy-frontend/app-main/.env.local.example
@@ -2,6 +2,7 @@
 # Run `../../generate_env.sh` to copy this file to `.env.local`.
 # Adjust the domain and analytics settings as needed.
 NEXT_PUBLIC_HIBP_PROXY_URL=http://localhost:8000/
+HIBP_PROXY_INTERNAL_URL=http://backend:8000/
 NEXT_PUBLIC_GA_MEASUREMENT_ID=<google_analytics_measurement_id>
 NEXT_PUBLIC_CONTACT_EMAIL=user@mail.com
 NEXTAUTH_SECRET=<your_nextauth_secret>

--- a/pwned-proxy-frontend/app-main/app/api/breach-check/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/breach-check/route.ts
@@ -15,8 +15,9 @@ export async function POST(request: NextRequest) {
 
     // Server‑side call to your Django API – no CORS issues here
     const baseUrl = (
+      process.env.HIBP_PROXY_INTERNAL_URL ||
       process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'http://localhost:8000'
+      'http://backend:8000'
     ).replace(/\/$/, '');
     const response = await fetch(
       `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`,

--- a/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 
 export async function GET() {
   const baseUrl = (
+    process.env.HIBP_PROXY_INTERNAL_URL ||
     process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-    'http://localhost:8000'
+    'http://backend:8000'
   ).replace(/\/$/, '');
   const apiKey = process.env.HIBP_API_KEY ?? '';
 

--- a/pwned-proxy-frontend/app-main/app/api/public-breach-check/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/public-breach-check/route.ts
@@ -6,8 +6,9 @@ export async function POST(request: NextRequest) {
 
     // Server-side call to the Django API without requiring Authorization
     const baseUrl = (
+      process.env.HIBP_PROXY_INTERNAL_URL ||
       process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'http://localhost:8000'
+      'http://backend:8000'
     ).replace(/\/$/, '');
     const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`;
     const response = await fetch(apiUrl, {


### PR DESCRIPTION
## Summary
- add `HIBP_PROXY_INTERNAL_URL` to frontend env example
- use new variable in server-side API routes so containerized frontend can reach the backend

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_687800e427b4832c9e1b4de2fb791abb