### PR TITLE
Fix about page group names lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ automatically so you only need to supply your domains and HIBP key afterwards:
 The script copies `pwned-proxy-frontend/app-main/.env.local.example` to
 `pwned-proxy-frontend/app-main/.env.local` and generates a new
 `pwned-proxy-backend/.env`. Edit the generated files to set
-`HIBP_API_KEY` and your domain names.
+`HIBP_API_KEY` and your domain names. When running the Docker stack, keep
+`HIBP_PROXY_INTERNAL_URL` set to `http://backend:8000` so the frontend can
+reach the API container.
 
 ### 4. Start the stack
 

--- a/pwned-proxy-backend/app-main/api/tests/__init__.py
+++ b/pwned-proxy-backend/app-main/api/tests/__init__.py
@@ -1,1 +1,12 @@
+"""Test helpers for the API package."""
+
+import django
+from django.conf import settings
+
+# Ensure Django is configured when running the tests directly with pytest.
+if not settings.configured:
+    import os
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pwned_proxy.settings")
+    django.setup()
+
 from .test_urls import *  # noqa

--- a/pwned-proxy-frontend/app-main/app/api/breach-check/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/breach-check/route.ts
@@ -14,11 +14,11 @@ export async function POST(request: NextRequest) {
     }
 
     // Server‑side call to your Django API – no CORS issues here
-    const baseUrl = (
-      process.env.HIBP_PROXY_INTERNAL_URL ||
-      process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'http://backend:8000'
-    ).replace(/\/$/, '');
+  // Prefer the internal backend hostname when running inside Docker.
+  const baseUrl = (
+    process.env.HIBP_PROXY_INTERNAL_URL ||
+    'http://backend:8000'
+  ).replace(/\/$/, '');
     const response = await fetch(
       `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`,
       {

--- a/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
+  // Always prefer the internal backend URL when available. Falling back to the
+  // backend container hostname ensures the API can be reached when the public
+  // URL (often pointing to localhost) isn't accessible from within the
+  // container network.
   const baseUrl = (
     process.env.HIBP_PROXY_INTERNAL_URL ||
-    process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
     'http://backend:8000'
   ).replace(/\/$/, '');
   const apiKey = process.env.HIBP_API_KEY ?? '';

--- a/pwned-proxy-frontend/app-main/app/api/public-breach-check/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/public-breach-check/route.ts
@@ -5,11 +5,11 @@ export async function POST(request: NextRequest) {
     const { email } = await request.json();
 
     // Server-side call to the Django API without requiring Authorization
-    const baseUrl = (
-      process.env.HIBP_PROXY_INTERNAL_URL ||
-      process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'http://backend:8000'
-    ).replace(/\/$/, '');
+  // Prefer the internal backend hostname when running inside Docker.
+  const baseUrl = (
+    process.env.HIBP_PROXY_INTERNAL_URL ||
+    'http://backend:8000'
+  ).replace(/\/$/, '');
     const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`;
     const response = await fetch(apiUrl, {
       method: 'GET',


### PR DESCRIPTION
## Summary
- use internal backend hostname for Next.js API calls
- document the internal URL variable in the README
- ensure Django is configured when running unit tests

## Testing
- `PYTHONPATH=pwned-proxy-backend DJANGO_SETTINGS_MODULE=pwned_proxy.settings pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687806420a44832caf7bc0c02e7fc0aa