### PR TITLE
Fix devcontainer DB credentials

### DIFF
--- a/.devcontainer/DEVELOPMENT_GUIDE.md
+++ b/.devcontainer/DEVELOPMENT_GUIDE.md
@@ -73,6 +73,9 @@ The PostgreSQL database is automatically started with the devcontainer and is ac
 - **Database**: `dev-db`
 - **Username**: `postgres`
 - **Password**: `postgres`
+  
+These credentials are exported automatically when the devcontainer starts so
+Django can connect without any extra configuration.
 
 ## Environment Files
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     environment:
       - PYTHONPATH=/usr/src/project
       - POSTGRES_HOST=dev-db
+      - POSTGRES_DB=dev-db
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
     depends_on:
       - dev-db
     networks:

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -26,6 +26,11 @@ fi
 # Export backend environment variables so helper scripts can access them
 set -a
 source pwned-proxy-backend/.env
+# Use static credentials for the dev database
+POSTGRES_HOST=dev-db
+POSTGRES_DB=dev-db
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
 set +a
 
 # Apply migrations and create the default admin user


### PR DESCRIPTION
## Summary
- keep Django env consistent by exporting dev DB creds in `postStartCommand.sh`
- expose the dev DB creds in `docker-compose.yml`
- document automatic credential export in the development guide

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6878e2cfd6bc832c9fee7baee42ae853