### PR TITLE
Fix generate_env.sh permissions in devcontainer

### DIFF
--- a/.devcontainer/DEVELOPMENT_GUIDE.md
+++ b/.devcontainer/DEVELOPMENT_GUIDE.md
@@ -4,6 +4,11 @@
 
 ### In Development Container
 
+The container now runs as the non-root `devuser`. If your host account
+uses a different UID or GID you can override the build arguments
+`LOCAL_UID` and `LOCAL_GID` when building the devcontainer to ensure the
+mounted workspace remains writable.
+
 1. **Set up environment variables (optional):**
    The dev container automatically generates `pwned-proxy-backend/.env` on first
    start. Re-run `generate_env.sh` only if you want to regenerate the file.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,3 +14,19 @@ ENV PATH="/usr/venv/backend/bin:$PATH"
 
 # Set default workdir
 WORKDIR /usr/src/project
+
+# Create non-root user so the workspace is writable when the host
+# directory is mounted with root squash. Grant passwordless sudo so
+# postStartCommand.sh can install optional tooling.
+ARG USERNAME=devuser
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN apt-get update && apt-get install -y sudo \
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && chown -R $USERNAME:$USERNAME /usr/venv/backend /usr/src/project
+
+# Use the non-root user by default
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
     "dockerComposeFile": "docker-compose.yml",
     "service": "devcontainer",
     "workspaceFolder": "/usr/src/project",
-    "remoteUser": "root",
+    "remoteUser": "devuser",
     "forwardPorts": [8000, 3000],
     "customizations": {
         "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        USER_UID: ${LOCAL_UID:-1000}
+        USER_GID: ${LOCAL_GID:-1000}
     volumes:
       - ../:/usr/src/project
     working_dir: /usr/src/project

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -46,9 +46,9 @@ fi
 # Configure ngrok when token provided
 if [ -n "${DEVCONTAINER_NGROK_AUTHTOKEN}" ]; then
     curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc |
-        tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+        sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
     echo "deb https://ngrok-agent.s3.amazonaws.com buster main" |
-        tee /etc/apt/sources.list.d/ngrok.list
-    apt-get update && apt-get install -y ngrok
+        sudo tee /etc/apt/sources.list.d/ngrok.list
+    sudo apt-get update && sudo apt-get install -y ngrok
     ngrok config add-authtoken "$DEVCONTAINER_NGROK_AUTHTOKEN"
 fi


### PR DESCRIPTION
## Summary
- run dev container as non-root user
- allow overriding UID/GID via build args
- adjust postStartCommand to use sudo
- document new devcontainer setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e6ebf194832c8c95ae65fb662ade