### PR TITLE
Fix group-names endpoint in devcontainer

### DIFF
--- a/.devcontainer/DEVELOPMENT_GUIDE.md
+++ b/.devcontainer/DEVELOPMENT_GUIDE.md
@@ -80,6 +80,10 @@ Make sure to create the necessary environment files:
 - `pwned-proxy-backend/.env` (created by `generate_env.sh`)
 - `pwned-proxy-frontend/app-main/.env.local`
 
+When using the devcontainer the backend and frontend share the same
+container. Set `HIBP_PROXY_INTERNAL_URL` in `.env.local` to
+`http://localhost:8000` so the frontend can reach the Django server.
+
 ## Development Workflow
 
 1. Start the devcontainer

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ automatically so you only need to supply your domains and HIBP key afterwards:
 The script copies `pwned-proxy-frontend/app-main/.env.local.example` to
 `pwned-proxy-frontend/app-main/.env.local` and generates a new
 `pwned-proxy-backend/.env`. Edit the generated files to set
-`HIBP_API_KEY` and your domain names. When running the Docker stack, keep
-`HIBP_PROXY_INTERNAL_URL` set to `http://backend:8000` so the frontend can
-reach the API container.
+`HIBP_API_KEY` and your domain names.
+
+When running the Docker stack, keep `HIBP_PROXY_INTERNAL_URL` set to
+`http://backend:8000` so the frontend can reach the API container. In the
+devcontainer where both services run in the same container, change it to
+`http://localhost:8000`.
 
 ### 4. Start the stack
 

--- a/pwned-proxy-backend/app-main/api/views.py
+++ b/pwned-proxy-backend/app-main/api/views.py
@@ -456,4 +456,5 @@ class GroupNamesView(LoggedAPIView):
     def get(self, request):
         print("[backend] GroupNamesView reached")
         names = list(Group.objects.order_by("name").values_list("name", flat=True))
+        print("[backend] returning", names)
         return Response(names, status=200)

--- a/pwned-proxy-frontend/app-main/.env.local.example
+++ b/pwned-proxy-frontend/app-main/.env.local.example
@@ -2,7 +2,10 @@
 # Run `../../generate_env.sh` to copy this file to `.env.local`.
 # Adjust the domain and analytics settings as needed.
 NEXT_PUBLIC_HIBP_PROXY_URL=http://localhost:8000/
-HIBP_PROXY_INTERNAL_URL=http://backend:8000/
+# Backend URL reachable from the frontend. Use http://backend:8000/ when running
+# the Docker Compose stack, otherwise http://localhost:8000/ works in the
+# devcontainer.
+HIBP_PROXY_INTERNAL_URL=http://localhost:8000/
 NEXT_PUBLIC_GA_MEASUREMENT_ID=<google_analytics_measurement_id>
 NEXT_PUBLIC_CONTACT_EMAIL=user@mail.com
 NEXTAUTH_SECRET=<your_nextauth_secret>

--- a/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/group-names/route.ts
@@ -32,6 +32,7 @@ export async function GET() {
     }
 
     const data = JSON.parse(text);
+    console.log('[group-names] parsed data:', data);
     if (!Array.isArray(data)) {
       return NextResponse.json(
         { error: 'Invalid groups payload from backend' },


### PR DESCRIPTION
## Summary
- ensure `HIBP_PROXY_INTERNAL_URL` defaults to localhost for devcontainer
- document variable in README and devcontainer guide
- log returned group names from backend
- log parsed JSON in frontend

## Testing
- `python3 manage.py test api`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878ef139994832cbe94d7e23e217be7