### PR TITLE
Fix Swagger links use https

### DIFF
--- a/pwned-proxy-backend/README.md
+++ b/pwned-proxy-backend/README.md
@@ -125,6 +125,8 @@ server {
         proxy_pass http://localhost:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        # Tell Django the original scheme so Swagger links use HTTPS
+        proxy_set_header X-Forwarded-Proto https;
     }
 }
 ```
@@ -133,6 +135,16 @@ Use a tool like `certbot` to obtain TLS certificates and update the
 server block to listen on port `443` with SSL enabled. Once configured,
 requests to `https://example.com` will be forwarded to the Dockerized
 Django application.
+
+If you use **Apache** instead of Nginx, add a similar header inside your
+`VirtualHost` block:
+
+```apache
+RequestHeader set X-Forwarded-Proto "https"
+```
+
+The application relies on this header to detect that it's running behind
+HTTPS so Swagger links are generated with the correct scheme.
 
 ## Developing with VS Code
 

--- a/pwned-proxy-backend/app-main/pwned_proxy/urls.py
+++ b/pwned-proxy-backend/app-main/pwned_proxy/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import path, include
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
+from django.conf import settings
 from rest_framework import permissions
 
 schema_view = get_schema_view(
@@ -12,6 +13,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),
+    url=f"{'https' if not settings.DEBUG else 'http'}://{settings.PWNED_PROXY_DOMAIN}",
 )
 
 urlpatterns = [

--- a/pwned-proxy-frontend/README.md
+++ b/pwned-proxy-frontend/README.md
@@ -4,8 +4,10 @@
 
 Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_HIBP_PROXY_URL`
 if you wish to use a different API location. By default it points to
-`http://localhost:8000/`. This variable is read by the
-start page and the header link so it also works when deployed with Coolify.
+`http://localhost:8000/`. When deploying publicly over TLS update this to use
+`https://<your-domain>` so Swagger loads the API through HTTPS. This variable is
+read by the start page and the header link so it also works when deployed with
+Coolify.
 
 ### Google Analytics
 

--- a/pwned-proxy-frontend/app-main/.env.local.example
+++ b/pwned-proxy-frontend/app-main/.env.local.example
@@ -1,6 +1,8 @@
 # Example frontend environment
 # Run `../../generate_env.sh` to copy this file to `.env.local`.
 # Adjust the domain and analytics settings as needed.
+# Base URL to the Django backend. When deploying behind HTTPS make sure this
+# starts with "https://" so Swagger generates secure links.
 NEXT_PUBLIC_HIBP_PROXY_URL=http://localhost:8000/
 # Backend URL reachable from the frontend. Use http://backend:8000/ when running
 # the Docker Compose stack, otherwise http://localhost:8000/ works in the


### PR DESCRIPTION
## Summary
- default Swagger base URL to `https://<domain>` when not in debug mode
- document `X-Forwarded-Proto` header requirements for Nginx and Apache

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_687a29689b28832cb40013a973f7d7d8