### PR TITLE
Ensure docker-compose restarts containers automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,10 @@ then building the images:
 docker compose build && docker compose up -d
 ```
 
+All services now include a `restart: unless-stopped` policy in
+`docker-compose.yaml`. Docker automatically recreates them when the
+daemon restarts, for example after a server reboot. Ensure the Docker
+service itself is enabled with `sudo systemctl enable docker` so the
+stack starts on boot.
+
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
     networks:
       - private   # talk to Postgres
       - public    # talk to frontend / Internet
+    restart: unless-stopped
 
   frontend:
     build:
@@ -27,6 +28,7 @@ services:
       - "127.0.0.1:3000:3000"
     networks:
       - public    # talk to backend / Internet
+    restart: unless-stopped
 
   db:
     image: postgres:14-alpine
@@ -36,6 +38,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - private   # only backend can see this
+    restart: unless-stopped
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- set restart policy to `unless-stopped` for backend, frontend and db
- document automatic startup after reboot

## Testing
- `git ls-files '*.py' -z | xargs -0 python3 -m py_compile`
- `python3 - <<'PY'
import yaml
with open('docker-compose.yaml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_687e394b86b0832c88f84d41bed5bd82