### PR TITLE
Remove swagger login/authorize controls

### DIFF
--- a/pwned-proxy-backend/app-main/pwned_proxy/settings.py
+++ b/pwned-proxy-backend/app-main/pwned_proxy/settings.py
@@ -217,3 +217,9 @@ USE_X_FORWARDED_HOST = True
 # sets the X-Frame-Options header to 'DENY' which prevents embedding. Setting
 # it to 'ALLOWALL' removes the header so the site can be framed by any origin.
 X_FRAME_OPTIONS = 'ALLOWALL'
+
+# Hide login and authorize controls in the Swagger UI
+SWAGGER_SETTINGS = {
+    'USE_SESSION_AUTH': False,
+    'SECURITY_DEFINITIONS': None,
+}


### PR DESCRIPTION
## Summary
- disable session auth and security definitions for Swagger UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e39941264832cabaf552932299476