### PR TITLE
Add API key rotation in admin

### DIFF
--- a/pwned-proxy-backend/app-main/api/templates/admin/api/apikey/change_form.html
+++ b/pwned-proxy-backend/app-main/api/templates/admin/api/apikey/change_form.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    {% if change %}
+    <li>
+        <a href="{% url 'admin:api_apikey_rotate' original.pk %}" class="button"
+           onclick="return confirm('{% translate "The API key will be rotated and shown once. Continue?" %}');">
+            {% translate "Rotate API Key" %}
+        </a>
+    </li>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a rotate action and per-key rotate button in the Django admin
- display rotated keys in a success message
- add custom template for APIKey change form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'envutils')*

------
https://chatgpt.com/codex/tasks/task_e_687e3bd22c08832cb8c61810de4065ad