### PR TITLE
Store API keys in plaintext

### DIFF
--- a/pwned-proxy-backend/app-main/api/admin.py
+++ b/pwned-proxy-backend/app-main/api/admin.py
@@ -6,13 +6,13 @@ from django.shortcuts import redirect, get_object_or_404
 from django.urls import path
 from django.utils.html import format_html
 
-from .models import APIKey, Domain, generate_api_key, hash_api_key, EndpointLog
+from .models import APIKey, Domain, generate_api_key, EndpointLog
 
 @admin.register(APIKey)
 class APIKeyAdmin(admin.ModelAdmin):
-    list_display = ('id', 'group', 'domain_list', 'hashed_key', 'created_at')
-    search_fields = ('hashed_key',)
-    readonly_fields = ('hashed_key', 'created_at')
+    list_display = ('id', 'group', 'domain_list', 'key', 'created_at')
+    search_fields = ('key',)
+    readonly_fields = ('created_at',)
     filter_horizontal = ('domains',)
     actions = ['rotate_api_keys']
 
@@ -24,11 +24,10 @@ class APIKeyAdmin(admin.ModelAdmin):
     domain_list.short_description = "Domains"
 
     def save_model(self, request, obj, form, change):
-        if not change:  # brand-new APIKey
-            raw_key = generate_api_key()
-            obj.hashed_key = hash_api_key(raw_key)
+        if not change and not obj.key:
+            obj.key = generate_api_key()
             super().save_model(request, obj, form, change)
-            self.message_user(request, f"Your new API key: {raw_key}", level=messages.SUCCESS)
+            self.message_user(request, f"Your new API key: {obj.key}", level=messages.SUCCESS)
         else:
             super().save_model(request, obj, form, change)
 
@@ -37,7 +36,7 @@ class APIKeyAdmin(admin.ModelAdmin):
         messages_list = []
         for api_key in queryset:
             raw_key = generate_api_key()
-            api_key.hashed_key = hash_api_key(raw_key)
+            api_key.key = raw_key
             api_key.save()
             messages_list.append(f"{api_key.group or api_key.id}: {raw_key}")
 
@@ -67,7 +66,7 @@ class APIKeyAdmin(admin.ModelAdmin):
     def rotate_single_api_key(self, request, pk):
         api_key = get_object_or_404(APIKey, pk=pk)
         raw_key = generate_api_key()
-        api_key.hashed_key = hash_api_key(raw_key)
+        api_key.key = raw_key
         api_key.save()
         self.message_user(request, f"API key rotated. New key: {raw_key}", level=messages.SUCCESS)
         return redirect("../")
@@ -138,7 +137,7 @@ from django.core.management import call_command
 from django.shortcuts import redirect
 from django.urls import path
 
-from .models import APIKey, Domain, generate_api_key, hash_api_key, HIBPKey
+from .models import APIKey, Domain, generate_api_key, HIBPKey
 
 @admin.register(HIBPKey)
 class HIBPKeyAdmin(admin.ModelAdmin):

--- a/pwned-proxy-backend/app-main/api/authentication.py
+++ b/pwned-proxy-backend/app-main/api/authentication.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
-from .models import APIKey, hash_api_key
+from .models import APIKey
 
 User = get_user_model()
 
@@ -17,7 +17,7 @@ User = get_user_model()
 class APIKeyAuthentication(BaseAuthentication):
     """
     Looks for 'X-API-Key' or 'hibp-api-key' in headers,
-    compares hashed value to stored APIKeys.
+    matches it directly against stored API keys.
     """
 
     def authenticate(self, request):
@@ -25,9 +25,8 @@ class APIKeyAuthentication(BaseAuthentication):
         if not raw_key:
             return None  # No API key => DRF tries next auth class
 
-        hashed = hash_api_key(raw_key)
         try:
-            api_key = APIKey.objects.get(hashed_key=hashed)
+            api_key = APIKey.objects.get(key=raw_key)
         except APIKey.DoesNotExist:
             raise AuthenticationFailed("Invalid API Key")
 

--- a/pwned-proxy-backend/app-main/api/migrations/0003_apikey_plaintext.py
+++ b/pwned-proxy-backend/app-main/api/migrations/0003_apikey_plaintext.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0002_endpointlog'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='apikey',
+            old_name='hashed_key',
+            new_name='key',
+        ),
+    ]


### PR DESCRIPTION
## Summary
- store API keys as plaintext instead of hashes
- allow editing API keys in the admin
- adjust admin actions and authentication to use plaintext keys
- add migration to rename field

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e437e6a98832c92ae5cb68f5fcff2