### PR TITLE
Require groups for API keys

### DIFF
--- a/pwned-proxy-backend/app-main/api/migrations/0003_apikey_group_required.py
+++ b/pwned-proxy-backend/app-main/api/migrations/0003_apikey_group_required.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+def remove_null_group_keys(apps, schema_editor):
+    APIKey = apps.get_model('api', 'APIKey')
+    APIKey.objects.filter(group__isnull=True).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0002_endpointlog'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_null_group_keys, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='apikey',
+            name='group',
+            field=models.ForeignKey(on_delete=models.CASCADE, related_name='api_keys', to='auth.group'),
+        ),
+    ]

--- a/pwned-proxy-backend/app-main/api/models.py
+++ b/pwned-proxy-backend/app-main/api/models.py
@@ -55,9 +55,7 @@ class APIKey(models.Model):
     group = models.ForeignKey(
         Group,
         on_delete=models.CASCADE,
-        related_name='api_keys',
-        null=True,
-        blank=True
+        related_name='api_keys'
     )
     # Instead of a single "allowed_domain" CharField, now we allow many:
     domains = models.ManyToManyField(Domain, blank=True)


### PR DESCRIPTION
## Summary
- make `group` on `APIKey` non-nullable
- clean up any keys without a group before migrating

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=pwned-proxy-backend/app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python pwned-proxy-backend/manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_687e3c03cfe4832c9e64db0c67a3d96e