### PR TITLE
Add export/import for group API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Import the domain list:
 
 ![Import domains](https://supabase.vicre-nextjs-01.security.ait.dtu.dk/storage/v1/object/public/hibp-guide/4.1-django-importdomains.png)
 
-Generate client API keys and download `seeded_api_keys.json`:
+Generate client API keys and download `seeded_api_keys.json`.  The **Groups** page
+also provides buttons to export and import the current group/API key mapping for
+backup purposes:
 
 ![Seed keys](https://supabase.vicre-nextjs-01.security.ait.dtu.dk/storage/v1/object/public/hibp-guide/5.2-django-seed-and-download-clienthibpkeys.png)
 

--- a/pwned-proxy-backend/README.md
+++ b/pwned-proxy-backend/README.md
@@ -59,7 +59,7 @@ superuser credentials you provided.
 1. After logging into the Django admin, add your [Have I Been Pwned](https://haveibeenpwned.com/api) API key:
    - Navigate to **HIBP Keys** and create a new key with the value you received from HIBP.
 2. Go to **Domains** and click **Import from HIBP**. This populates the database with the latest domain data.
-3. Open **Groups** and use the **Seed Groups** action to generate API keys for each predefined group. The keys are downloaded as a JSON file.
+3. Open **Groups** and use the **Seed Groups** action to generate API keys for each predefined group. The keys are downloaded as a JSON file. The same page also lets you export or import the group/API key mapping at any time for backup.
 4. Finally, visit `http://localhost:8000/` to open the Swagger start page and try out the API using the generated keys.
 
 ## Running tests

--- a/pwned-proxy-backend/app-main/api/templates/admin/auth/group/change_list.html
+++ b/pwned-proxy-backend/app-main/api/templates/admin/auth/group/change_list.html
@@ -10,6 +10,18 @@
       </a>
     </li>
 
+    <li style="list-style: none; margin-bottom: 30px;">
+      <a href="{% url 'admin:export_groups_keys' %}" class="button">
+        {% trans "Export Groups & API Keys" %}
+      </a>
+    </li>
+
+    <li style="list-style: none; margin-bottom: 30px;">
+      <a href="{% url 'admin:import_groups_keys' %}" class="button">
+        {% trans "Import Groups & API Keys" %}
+      </a>
+    </li>
+
     <script type="text/javascript">
       function confirmSeed() {
         if (confirm("All API keys will be overwritten. Do you want to proceed?")) {

--- a/pwned-proxy-backend/app-main/api/templates/admin/auth/group/import_form.html
+++ b/pwned-proxy-backend/app-main/api/templates/admin/auth/group/import_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "Import Groups and API Keys" %}</h1>
+<form method="post" enctype="multipart/form-data" style="margin-top: 1em;">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <input type="submit" class="default" value="{% trans 'Import' %}">
+</form>
+{% endblock %}

--- a/pwned-proxy-backend/app-main/api/tests/seeded_api_keys.json.example
+++ b/pwned-proxy-backend/app-main/api/tests/seeded_api_keys.json.example
@@ -1,11 +1,51 @@
 [
-  {"group_name": "Aalborg Universitet", "raw_key": "example-key-aau", "domains": ["aau.dk"]},
-  {"group_name": "Roskilde Universitet", "raw_key": "example-key-ruc", "domains": ["ruc.dk"]},
-  {"group_name": "Københavns Universitet", "raw_key": "example-key-ku", "domains": ["ku.dk"]},
-  {"group_name": "Niels Bohr Institutet", "raw_key": "example-key-nbi", "domains": ["nbi.dk"]},
-  {"group_name": "IT-Universitetet i København", "raw_key": "example-key-itu", "domains": ["itu.dk"]},
-  {"group_name": "Danmarks Tekniske Universitet", "raw_key": "example-key-dtu", "domains": ["dtu.dk"]},
-  {"group_name": "Danish e-Infrastructure Cooperation", "raw_key": "example-key-deic", "domains": ["deic.dk"]},
-  {"group_name": "Danish e-Infrastructure Cooperation", "raw_key": "example-key-cert", "domains": ["cert.dk"]},
-  {"group_name": "Copenhagen Business School", "raw_key": "example-key-cbs", "domains": ["cbs.dk"]}
+  {
+    "group_name": "Aalborg Universitet",
+    "api_keys": [
+      {"raw_key": "example-key-aau", "domains": ["aau.dk"]}
+    ]
+  },
+  {
+    "group_name": "Roskilde Universitet",
+    "api_keys": [
+      {"raw_key": "example-key-ruc", "domains": ["ruc.dk"]}
+    ]
+  },
+  {
+    "group_name": "K\u00f8benhavns Universitet",
+    "api_keys": [
+      {"raw_key": "example-key-ku", "domains": ["ku.dk"]}
+    ]
+  },
+  {
+    "group_name": "Niels Bohr Institutet",
+    "api_keys": [
+      {"raw_key": "example-key-nbi", "domains": ["nbi.dk"]}
+    ]
+  },
+  {
+    "group_name": "IT-Universitetet i K\u00f8benhavn",
+    "api_keys": [
+      {"raw_key": "example-key-itu", "domains": ["itu.dk"]}
+    ]
+  },
+  {
+    "group_name": "Danmarks Tekniske Universitet",
+    "api_keys": [
+      {"raw_key": "example-key-dtu", "domains": ["dtu.dk"]}
+    ]
+  },
+  {
+    "group_name": "Danish e-Infrastructure Cooperation",
+    "api_keys": [
+      {"raw_key": "example-key-deic", "domains": ["deic.dk"]},
+      {"raw_key": "example-key-cert", "domains": ["cert.dk"]}
+    ]
+  },
+  {
+    "group_name": "Copenhagen Business School",
+    "api_keys": [
+      {"raw_key": "example-key-cbs", "domains": ["cbs.dk"]}
+    ]
+  }
 ]


### PR DESCRIPTION
## Summary
- extend group admin with export/import of API keys
- group seeding now outputs multiple keys per group
- add buttons for exporting and importing group key mapping
- document new functionality

## Testing
- `pip install -r pwned-proxy-backend/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_687e48540bc8832cad28079e419de4b5