### PR TITLE
Add name and description fields to API keys

### DIFF
--- a/pwned-proxy-backend/app-main/api/admin.py
+++ b/pwned-proxy-backend/app-main/api/admin.py
@@ -10,8 +10,8 @@ from .models import APIKey, Domain, generate_api_key, EndpointLog
 
 @admin.register(APIKey)
 class APIKeyAdmin(admin.ModelAdmin):
-    list_display = ('id', 'group', 'domain_list', 'key', 'created_at')
-    search_fields = ('key',)
+    list_display = ('id', 'name', 'group', 'domain_list', 'key', 'created_at')
+    search_fields = ('name', 'description', 'key')
     readonly_fields = ('created_at',)
     filter_horizontal = ('domains',)
     actions = ['rotate_api_keys']
@@ -228,7 +228,11 @@ class CustomGroupAdmin(GroupAdmin):
             base_domain = item["domain"]
 
             group, _created = Group.objects.get_or_create(name=group_name)
-            api_key_obj, raw_key = APIKey.create_api_key(group=group)
+            api_key_obj, raw_key = APIKey.create_api_key(
+                group=group,
+                name=f"Seed key for {group_name}",
+                description="Initial seed key",
+            )
 
             # find all matching domains
             matching_domains = Domain.objects.filter(name__endswith=base_domain)

--- a/pwned-proxy-backend/app-main/api/management/commands/initial_setup.py
+++ b/pwned-proxy-backend/app-main/api/management/commands/initial_setup.py
@@ -53,7 +53,11 @@ class Command(BaseCommand):
                 group_name = item["group"]
                 base_domain = item["domain"]
                 group, _ = Group.objects.get_or_create(name=group_name)
-                api_key_obj, raw_key = APIKey.create_api_key(group=group)
+                api_key_obj, raw_key = APIKey.create_api_key(
+                    group=group,
+                    name=f"Seed key for {group_name}",
+                    description="Initial seed key",
+                )
                 matching = Domain.objects.filter(name__endswith=base_domain)
                 api_key_obj.domains.add(*matching)
                 results.append({"group": group_name, "api_key": raw_key})

--- a/pwned-proxy-backend/app-main/api/migrations/0004_apikey_name_description.py
+++ b/pwned-proxy-backend/app-main/api/migrations/0004_apikey_name_description.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+def set_default_names(apps, schema_editor):
+    APIKey = apps.get_model('api', 'APIKey')
+    for obj in APIKey.objects.all():
+        if not obj.name:
+            obj.name = f"Key for {obj.group.name if obj.group_id else obj.pk}"
+            obj.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0003_apikey_plaintext'),
+        ('api', '0003_apikey_group_required'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='apikey',
+            name='name',
+            field=models.CharField(default='', max_length=255),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='apikey',
+            name='description',
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.RunPython(set_default_names, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- allow APIKey to store a name and optional description
- show the new fields in the admin
- update seed/initial setup commands to populate these fields
- include migration for new columns

## Testing
- `pytest pwned-proxy-backend/app-main/api/tests/test_urls.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e495da244832ca1f4cb808fef0bed