### PR TITLE
Hash API keys

### DIFF
--- a/pwned-proxy-backend/app-main/api/admin.py
+++ b/pwned-proxy-backend/app-main/api/admin.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect, get_object_or_404
 from django.urls import path
 from django.utils.html import format_html
 
-from .models import APIKey, Domain, generate_api_key, EndpointLog
+from .models import APIKey, Domain, generate_api_key, EndpointLog, hash_api_key
 
 @admin.register(APIKey)
 class APIKeyAdmin(admin.ModelAdmin):
@@ -25,9 +25,10 @@ class APIKeyAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         if not change and not obj.key:
-            obj.key = generate_api_key()
+            raw_key = generate_api_key()
+            obj.key = hash_api_key(raw_key)
             super().save_model(request, obj, form, change)
-            self.message_user(request, f"Your new API key: {obj.key}", level=messages.SUCCESS)
+            self.message_user(request, f"Your new API key: {raw_key}", level=messages.SUCCESS)
         else:
             super().save_model(request, obj, form, change)
 
@@ -36,7 +37,7 @@ class APIKeyAdmin(admin.ModelAdmin):
         messages_list = []
         for api_key in queryset:
             raw_key = generate_api_key()
-            api_key.key = raw_key
+            api_key.key = hash_api_key(raw_key)
             api_key.save()
             messages_list.append(f"{api_key.group or api_key.id}: {raw_key}")
 
@@ -64,7 +65,7 @@ class APIKeyAdmin(admin.ModelAdmin):
     def rotate_single_api_key(self, request, pk):
         api_key = get_object_or_404(APIKey, pk=pk)
         raw_key = generate_api_key()
-        api_key.key = raw_key
+        api_key.key = hash_api_key(raw_key)
         api_key.save()
         self.message_user(request, f"API key rotated. New key: {raw_key}", level=messages.SUCCESS)
         return redirect("../")
@@ -274,7 +275,7 @@ class CustomGroupAdmin(GroupAdmin):
             key_list = []
             for api_key in group.api_keys.all():
                 key_list.append({
-                    "raw_key": api_key.key,
+                    "hashed_key": api_key.key,
                     "domains": list(api_key.domains.values_list('name', flat=True)),
                 })
             data.append({"group_name": group.name, "api_keys": key_list})
@@ -311,7 +312,7 @@ class CustomGroupAdmin(GroupAdmin):
                     APIKey.objects.filter(group=group).delete()
                     for key in entry.get('api_keys', []):
                         domains = list(Domain.objects.filter(name__in=key.get('domains', []) ))
-                        api_key = APIKey.objects.create(group=group, key=key.get('raw_key'))
+                        api_key = APIKey.objects.create(group=group, key=key.get('hashed_key'))
                         if domains:
                             api_key.domains.set(domains)
 

--- a/pwned-proxy-backend/app-main/api/authentication.py
+++ b/pwned-proxy-backend/app-main/api/authentication.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
-from .models import APIKey
+from .models import APIKey, hash_api_key
 
 User = get_user_model()
 
@@ -25,8 +25,9 @@ class APIKeyAuthentication(BaseAuthentication):
         if not raw_key:
             return None  # No API key => DRF tries next auth class
 
+        hashed = hash_api_key(raw_key)
         try:
-            api_key = APIKey.objects.get(key=raw_key)
+            api_key = APIKey.objects.get(key=hashed)
         except APIKey.DoesNotExist:
             raise AuthenticationFailed("Invalid API Key")
 

--- a/pwned-proxy-backend/app-main/api/tests/__init__.py
+++ b/pwned-proxy-backend/app-main/api/tests/__init__.py
@@ -6,6 +6,18 @@ from django.conf import settings
 # Ensure Django is configured when running the tests directly with pytest.
 if not settings.configured:
     import os
+    import sys
+    from pathlib import Path
+
+    # Ensure the project root (containing ``app-main``) is on ``sys.path``
+    ROOT_DIR = Path(__file__).resolve().parents[3]
+    APP_MAIN = ROOT_DIR / "app-main"
+
+    # Add both the project root and ``app-main`` to ``sys.path`` so imports
+    # like ``envutils`` and the ``pwned_proxy`` package work during tests.
+    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, str(APP_MAIN))
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pwned_proxy.settings")
     django.setup()
 

--- a/pwned-proxy-backend/app-main/api/throttling.py
+++ b/pwned-proxy-backend/app-main/api/throttling.py
@@ -1,4 +1,5 @@
 from rest_framework.throttling import SimpleRateThrottle
+from .models import hash_api_key
 
 class APIKeyRateThrottle(SimpleRateThrottle):
     scope = 'apikey'
@@ -7,4 +8,4 @@ class APIKeyRateThrottle(SimpleRateThrottle):
         api_key = request.headers.get('X-API-Key')
         if not api_key:
             return None
-        return f"apikey_{api_key}"
+        return f"apikey_{hash_api_key(api_key)}"


### PR DESCRIPTION
## Summary
- hash API keys so only a SHA256 digest is stored
- adjust authentication and throttling to use hashed values
- rotate and create keys with hashes in admin
- fix tests to configure Django correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68834813e854832ca997a72438b4c35b