### PR TITLE
Fix import of groups and API keys

### DIFF
--- a/pwned-proxy-backend/app-main/api/templates/admin/auth/group/import_form.html
+++ b/pwned-proxy-backend/app-main/api/templates/admin/auth/group/import_form.html
@@ -3,9 +3,17 @@
 
 {% block content %}
 <h1>{% trans "Import Groups and API Keys" %}</h1>
+{% if conflicts %}
+  <div class="errors" style="margin-bottom:1em;">
+    <p>{% trans "The following groups already exist and will be overwritten:" %}</p>
+    <ul>
+      {% for name in conflicts %}<li>{{ name }}</li>{% endfor %}
+    </ul>
+  </div>
+{% endif %}
 <form method="post" enctype="multipart/form-data" style="margin-top: 1em;">
   {% csrf_token %}
   {{ form.as_p }}
-  <input type="submit" class="default" value="{% trans 'Import' %}">
+  <input type="submit" class="default" value="{% if needs_confirm %}{% trans 'Confirm Import' %}{% else %}{% trans 'Import' %}{% endif %}">
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- avoid missing `name` when creating API keys
- warn about existing groups or keys before overwriting
- update import template to show conflicts and confirm overwrite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883605ff848832c814022cdfddee56c