### PR TITLE
Improve git info endpoint fallback

### DIFF
--- a/pwned-proxy-frontend/app-main/app/api/git-info/route.ts
+++ b/pwned-proxy-frontend/app-main/app/api/git-info/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { execSync } from "child_process";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+export const dynamic = "force-dynamic";
+
+type GitInfo = {
+  branch?: string;
+  commit?: string;
+};
+
+function getEnvGitInfo(): GitInfo {
+  const envBranch =
+    process.env.VERCEL_GIT_COMMIT_REF ||
+    process.env.GIT_BRANCH ||
+    process.env.NEXT_PUBLIC_GIT_BRANCH;
+
+  const envCommit =
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.GIT_COMMIT_SHA ||
+    process.env.NEXT_PUBLIC_GIT_COMMIT_SHA;
+
+  return {
+    branch: envBranch ?? undefined,
+    commit: envCommit ? envCommit.slice(0, 7) : undefined,
+  };
+}
+
+function getGitDirInfo(): GitInfo {
+  try {
+    const gitDir = process.env.GIT_DIR || join(process.cwd(), ".git");
+
+    if (!existsSync(gitDir)) {
+      return {};
+    }
+
+    const headPath = join(gitDir, "HEAD");
+    const headContents = readFileSync(headPath, "utf8").trim();
+
+    if (!headContents) {
+      return {};
+    }
+
+    if (headContents.startsWith("ref:")) {
+      const refPath = headContents.replace("ref: ", "").trim();
+      const branch = refPath.split("/").pop();
+      const commitPath = join(gitDir, refPath);
+
+      if (existsSync(commitPath)) {
+        const commitContents = readFileSync(commitPath, "utf8").trim();
+        return { branch: branch ?? undefined, commit: commitContents.slice(0, 7) };
+      }
+
+      return { branch: branch ?? undefined };
+    }
+
+    // Detached HEAD state
+    return { commit: headContents.slice(0, 7) };
+  } catch (error) {
+    return {};
+  }
+}
+
+function getGitCommandInfo(): GitInfo {
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+
+    const commit = execSync("git rev-parse --short HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+
+    return { branch, commit };
+  } catch (error) {
+    return {};
+  }
+}
+
+export async function GET() {
+  const envInfo = getEnvGitInfo();
+  const gitInfo: GitInfo = { ...envInfo };
+
+  if (!gitInfo.branch || !gitInfo.commit) {
+    const dirInfo = getGitDirInfo();
+    gitInfo.branch = gitInfo.branch ?? dirInfo.branch;
+    gitInfo.commit = gitInfo.commit ?? dirInfo.commit;
+  }
+
+  if (!gitInfo.branch || !gitInfo.commit) {
+    const commandInfo = getGitCommandInfo();
+    gitInfo.branch = gitInfo.branch ?? commandInfo.branch;
+    gitInfo.commit = gitInfo.commit ?? commandInfo.commit;
+  }
+
+  if (!gitInfo.branch && !gitInfo.commit) {
+    return NextResponse.json({ error: "Git information unavailable" }, { status: 200 });
+  }
+
+  return NextResponse.json(gitInfo);
+}

--- a/pwned-proxy-frontend/app-main/app/components/Footer.tsx
+++ b/pwned-proxy-frontend/app-main/app/components/Footer.tsx
@@ -2,8 +2,13 @@
 
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Github } from "lucide-react";
+
+type GitInfo = {
+  branch?: string;
+  commit?: string;
+};
 
 export default function Footer() {
   // Keep track of user’s theme choice. Default is "auto".
@@ -48,6 +53,47 @@ export default function Footer() {
       localStorage.setItem("theme", theme);
     }
   }, [theme]);
+
+  const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
+  const [gitError, setGitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchGitInfo = async () => {
+      try {
+        const response = await fetch("/api/git-info");
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const data = (await response.json()) as GitInfo & { error?: string };
+        if (data.error) {
+          setGitError(data.error);
+          return;
+        }
+        setGitInfo(data);
+      } catch (error) {
+        setGitError("Unable to load git information");
+      }
+    };
+
+    fetchGitInfo();
+  }, []);
+
+  const versionLabel = useMemo(() => {
+    if (!gitInfo) {
+      return null;
+    }
+
+    const parts = [
+      gitInfo.branch ?? null,
+      gitInfo.commit ? `(${gitInfo.commit})` : null,
+    ].filter((value): value is string => Boolean(value));
+
+    if (parts.length === 0) {
+      return null;
+    }
+
+    return parts.join(" ");
+  }, [gitInfo]);
 
   return (
     <footer
@@ -100,6 +146,13 @@ export default function Footer() {
           <Github className="w-4 h-4 mr-1" />
           GitHub
         </a>
+        {versionLabel ? (
+          <span className="font-mono">{versionLabel}</span>
+        ) : gitError ? (
+          <span className="text-xs text-tnLight-muted dark:text-tnStorm-muted">
+            {gitError}
+          </span>
+        ) : null}
         <span>Get involved on GitHub!</span>
       </div>
     </footer>

--- a/pwned-proxy-frontend/app-main/next-env.d.ts
+++ b/pwned-proxy-frontend/app-main/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- read git metadata directly from the local .git directory when env vars are absent
- only invoke git commands if still needed so deployments can discover their own version without extra configuration

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e790d4bc58832cadbe9571c170f060